### PR TITLE
Update docs planning services

### DIFF
--- a/docs/planning/services.md
+++ b/docs/planning/services.md
@@ -82,10 +82,35 @@ Clicking of a Service Instance will drill down into a Service Instance Detail vi
 Shows:
 
 - General Metadata
+- Service plan
+- Service parameters (in the future thanks to OSB GET endpoints see [servicebroker/issues/159](https://github.com/openservicebrokerapi/servicebroker/issues/159)
 - Service keys for this instance
 
+Enable updates:
+- in service plans
+- in parameters
+
+Enable delete
 
 ### Service Instance Creation
 
-TODO
+Selection of service plan
+Selection of org and space
+Supports parameters with generated form created from JSON schema, see [stratos/issues/1434](https://github.com/cloudfoundry-incubator/stratos/issues/1434) 
 
+
+### Services Binding Detail view
+
+This will show a Service Binding.
+
+Shows:
+
+- Service Instance 
+- Bound Application (optional)
+- Service binding parameters (in the future thanks to OSB GET endpoints see [servicebroker/issues/159](https://github.com/openservicebrokerapi/servicebroker/issues/159)
+- Credentials (using JSON or in the future generated form thanks to binding credentials output JSON schemas [servicebroker/issues/116](https://github.com/openservicebrokerapi/servicebroker/issues/116)
+
+Enables updates:
+- in parameters (in future OSB spec version)
+
+Enables delete (i.e. unbind service from app)


### PR DESCRIPTION
## Description

Following the call on Wed Aprl 25th, see [minutes](https://docs.google.com/document/d/1DGxiU4FDBUDNiBJXFsRrNHSVrp66KAAixtpB0jQWNog/edit), here is feedback related to 1st class service support, with suggestions to:
- Refine service instance detailed view (with display params and enable updates)
- Refine service instance creation view (specifiy params through generated forms)
- Add service binding detailed view (with display params )

Additional feedback is the need to support for app development use cases which most often work within a single space and frequently need to switch among the app/service instance views. The stratos UX does not yet seem to support such use case as the org/space drilldown filtering which seems not persistent: 
* across pages when using right hand-side navigation
* across login/logout, i.e. the filtered org/spaces are not specified in the browser address bar to support permalinks 
